### PR TITLE
What's the reason for using `serialize()` and `json_encode()` to calculate the cache key?

### DIFF
--- a/spec/loophp/memoize/MemoizerSpec.php
+++ b/spec/loophp/memoize/MemoizerSpec.php
@@ -56,7 +56,7 @@ class MemoizerSpec extends ObjectBehavior
 
         $test(5);
 
-        if (false === $cacheStorage->offsetExists(sha1(serialize(json_encode([5]))))) {
+        if (false === $cacheStorage->offsetExists(sha1(serialize([5])))) {
             throw new Error('The cache hasn\'t been updated!');
         }
 

--- a/src/Memoizer.php
+++ b/src/Memoizer.php
@@ -23,7 +23,7 @@ final class Memoizer implements MemoizerInterface
              * @return mixed
              */
             static fn (...$arguments) => $cache[
-                    sha1(serialize(json_encode($arguments)))
+                    sha1(json_encode($arguments))
                     ] ??= ($closure)(...$arguments);
     }
 }

--- a/src/Memoizer.php
+++ b/src/Memoizer.php
@@ -23,7 +23,7 @@ final class Memoizer implements MemoizerInterface
              * @return mixed
              */
             static fn (...$arguments) => $cache[
-                    sha1(json_encode($arguments))
+                    sha1(serialize($arguments))
                     ] ??= ($closure)(...$arguments);
     }
 }


### PR DESCRIPTION
Wouldn't just using one of them be sufficient? I'm curious for the reason of using both.