### PR TITLE
Use null coalescing assignment operator

### DIFF
--- a/src/Memoizer.php
+++ b/src/Memoizer.php
@@ -12,7 +12,7 @@ final class Memoizer implements MemoizerInterface
 {
     public static function fromClosure(Closure $closure, ?ArrayObject $cache = null): Closure
     {
-        $cache = $cache ?? new ArrayObject();
+        $cache ??= new ArrayObject();
 
         return
             /**


### PR DESCRIPTION
This PR

* [x] Uses the "null coalescing assignment operator" for assigning the fallback value to `$cache`.